### PR TITLE
Arreglo guardado partida 02 12 22

### DIFF
--- a/Assets/RecompensaHandler.cs
+++ b/Assets/RecompensaHandler.cs
@@ -55,6 +55,8 @@ public class RecompensaHandler : MonoBehaviour
 
         PlayerPrefs.SetString("Estados Niveles", JsonUtility.ToJson(estados));
 
+        PlayerPrefs.Save();
+
     }
 
     void recompensaCommons(Personaje personaje)

--- a/Assets/Scenes/Intro.unity
+++ b/Assets/Scenes/Intro.unity
@@ -257,7 +257,6 @@ GameObject:
   - component: {fileID: 793488722}
   - component: {fileID: 793488721}
   - component: {fileID: 793488720}
-  - component: {fileID: 793488723}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -336,15 +335,3 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &793488723
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 793488719}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa41e129c2986d944bd9592a44088c0e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 


### PR DESCRIPTION
Se ha arreglado el problema en el guardado de los datos de la partida. El error estaba en un script en la escena Intro, que reseteaba los PlayerPrefs