### PR TITLE
Arreglo seleccion personajes batalla 02 12 22

### DIFF
--- a/Assets/RecompensaHandler.cs
+++ b/Assets/RecompensaHandler.cs
@@ -55,6 +55,8 @@ public class RecompensaHandler : MonoBehaviour
 
         PlayerPrefs.SetString("Estados Niveles", JsonUtility.ToJson(estados));
 
+        PlayerPrefs.Save();
+
     }
 
     void recompensaCommons(Personaje personaje)

--- a/Assets/Scenes/Intro.unity
+++ b/Assets/Scenes/Intro.unity
@@ -257,7 +257,6 @@ GameObject:
   - component: {fileID: 793488722}
   - component: {fileID: 793488721}
   - component: {fileID: 793488720}
-  - component: {fileID: 793488723}
   m_Layer: 0
   m_Name: Main Camera
   m_TagString: MainCamera
@@ -336,15 +335,3 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &793488723
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 793488719}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: fa41e129c2986d944bd9592a44088c0e, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 

--- a/Assets/Scripts/Batalla/BattleController.cs
+++ b/Assets/Scripts/Batalla/BattleController.cs
@@ -40,11 +40,11 @@ public class BattleController : MonoBehaviour
                     var pointer = Input.mousePosition;
                     inputController(pointer);
                 }
-                else if ((Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Ended))
+                /*else if ((Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Ended))
                 {
                     var pointer = Input.GetTouch(0).position;
                     inputController(pointer);
-                }
+                }*/
             }
         }
         
@@ -62,6 +62,21 @@ public class BattleController : MonoBehaviour
             {
                 if (hit.collider.gameObject.GetComponent<SeleccionableManager>().isSelectable())
                 {
+                    if(playerSelected != null)
+                    {
+                        Debug.Log("Hola");
+                        keyDic--;
+                        var lista = colores[keyDic];
+                        var indice = 0;
+                        foreach (var sprite in playerSelected.GetComponentsInChildren<SpriteRenderer>())
+                        {
+                            sprite.color = lista[indice];
+                            indice++;
+                        }
+                        colores.Remove(keyDic);
+                        
+                        
+                    }
                     playerSelected = hit.collider.gameObject;
                     var listacolores = new List<Color>();
                     foreach (var sprite in playerSelected.GetComponentsInChildren<SpriteRenderer>())

--- a/Assets/Scripts/Planificacion/PlanificationManager.cs
+++ b/Assets/Scripts/Planificacion/PlanificationManager.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 
 public class PlanificationManager : MonoBehaviour
 {
-    private GameObject playerSelected;
+    [SerializeField] private GameObject playerSelected;
     [SerializeField] private GameObject canvasParent;
     private int personajesSeleccionados = 0;
     [SerializeField] DataToBattle dataBattle;
@@ -32,11 +32,11 @@ public class PlanificationManager : MonoBehaviour
         {
             var pointer = new PointerEventData(EventSystem.current) { position = Input.mousePosition};
             inputController(pointer);
-        }else if((Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Began))
+        }/*else if((Input.touchCount > 0 && Input.GetTouch(0).phase == TouchPhase.Began))
         {
             var pointer = new PointerEventData(EventSystem.current) { position = Input.GetTouch(0).position };
             inputController(pointer);
-        }
+        }*/
     }
 
     private void inputController(PointerEventData pointer)
@@ -50,8 +50,30 @@ public class PlanificationManager : MonoBehaviour
             {
                 if (hit.gameObject.CompareTag("Player") && !hit.gameObject.transform.parent.CompareTag("Cell"))
                 {
-                    if (hit.gameObject.transform.Find("Character").GetComponent<SeleccionableManager>().isSelectable())
-                        playerSelected = hit.gameObject;
+                    if(playerSelected != null)
+                    {
+                        if(playerSelected.transform.Find("Character").GetComponent<PlayerController>().getPersonaje().GetRareza() == cargarScript.getRarezaAtual())
+                        {
+                            playerSelected.transform.SetParent(canvasParent.transform);
+                            playerSelected.transform.localScale = new Vector3(3, 3, 3);
+
+                            playerSelected.transform.Find("Ataque").gameObject.SetActive(true);
+                            playerSelected.transform.Find("Defensa").gameObject.SetActive(true);
+                            playerSelected.transform.Find("HP").gameObject.SetActive(true);
+                            playerSelected.transform.Find("Nivel").gameObject.SetActive(true);
+                            playerSelected.transform.Find("TipoAtaque").gameObject.SetActive(true);
+
+                            if (hit.gameObject.transform.Find("Character").GetComponent<SeleccionableManager>().isSelectable())
+                                playerSelected = hit.gameObject;
+
+                        }
+                    }
+                    else 
+                    {
+                        if (hit.gameObject.transform.Find("Character").GetComponent<SeleccionableManager>().isSelectable())
+                            playerSelected = hit.gameObject;
+                    }
+                    
                 }
                 else if (hit.gameObject.CompareTag("Cell"))
                 {


### PR DESCRIPTION
Se ha solucionado el error que hacía que al seleccionar un personaje en la fase de batalla, cuando se tenía otro seleccionado previamente, el primer personaje seleccionado siguiese con el resalto, haciendo parecer que se tenían varios personajes seleccionados.