### PR TITLE
Arreglo flujo menú de opciones batalla 2 12 2022

### DIFF
--- a/Assets/Scenes/Batalla.unity
+++ b/Assets/Scenes/Batalla.unity
@@ -7654,7 +7654,7 @@ GameObject:
   - component: {fileID: 1325080286}
   - component: {fileID: 1325080285}
   m_Layer: 5
-  m_Name: menu_ppl
+  m_Name: Terminar nivel
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -7700,7 +7700,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Menu Principal
+  m_text: Terminar nivel
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: db2f28f94d5978846913dd5a99116b63, type: 2}
   m_sharedMaterial: {fileID: -5118543241869315926, guid: db2f28f94d5978846913dd5a99116b63, type: 2}
@@ -7842,7 +7842,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: Menu
+          m_StringArgument: Seleccion de niveles
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!222 &1325080288

--- a/Assets/Scenes/Batalla.unity
+++ b/Assets/Scenes/Batalla.unity
@@ -6418,7 +6418,7 @@ MonoBehaviour:
   m_OnClick:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 0}
+      - m_Target: {fileID: 1939591539}
         m_TargetAssemblyTypeName: OptionsManager, Assembly-CSharp
         m_MethodName: cierraOpciones
         m_Mode: 1
@@ -6427,7 +6427,7 @@ MonoBehaviour:
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
-          m_StringArgument: Menu
+          m_StringArgument: Seleccion de niveles
           m_BoolArgument: 0
         m_CallState: 2
 --- !u!222 &1163676509


### PR DESCRIPTION
Se quieren añadir los cambios hechos sobre el flujo del menú de opciones de la batalla a la rama de desarrollo. Se han cambiado el botón de volver, ahora funcional, y el botón de menú principal se ha sustituido por un botón de terminar nivel, que devuelve al menú de selección de niveles.