### PR TITLE
Arreglo en el coste de los personajes super raros

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -1345,7 +1345,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: dcb3b834530cf2841b75009830a3fedf, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  dineroJugador: 1500
+  dineroJugador: 2500
 --- !u!1 &1134235860
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -7,7 +7,7 @@ using UnityEngine.Timeline;
 public class GameManager : MonoBehaviour
 {
     public static GameManager instance;
-    [SerializeField] private int dineroJugador = 1500;
+    [SerializeField] private int dineroJugador = 2500;
     private AudioClip clipMenu;
     public GameManager Instance
     {
@@ -44,7 +44,7 @@ public class GameManager : MonoBehaviour
         if (!PlayerPrefs.HasKey("PrimeraVez"))
         {
             PlayerPrefs.SetInt("PrimeraVez", 1);
-            dineroJugador = 1500;
+            dineroJugador = 2500;
             PlayerPrefs.SetInt("Dinero", dineroJugador);
             PlayerPrefs.Save();
         }

--- a/Assets/Scripts/Store/StoreManager.cs
+++ b/Assets/Scripts/Store/StoreManager.cs
@@ -138,7 +138,7 @@ public class StoreManager : MonoBehaviour
                 }
                 break;
             case Rareza.SUPER_RARO:
-                if (GameManager.instance.getDineroJugador() >= 1500)
+                if (GameManager.instance.getDineroJugador() >= 2500)
                 {
                     generateRandomCharacter();
                 }
@@ -298,7 +298,7 @@ public class StoreManager : MonoBehaviour
                 PlayerPrefs.SetString("rares", JsonUtility.ToJson(spl));
                 break;
             case Rareza.SUPER_RARO:
-                GameManager.instance.restarDinero(1500);
+                GameManager.instance.restarDinero(2500);
                 PlayerPrefs.SetString("superRares", JsonUtility.ToJson(spl));
                 
                 break;


### PR DESCRIPTION
Se quiere añadir el arreglo en los scripts y la escena de la tienda correspondiente a la compra de personajes super raros a la rama de desarrollo. Se ha corregido el coste de los personajes con rareza Super Raro, que tanto en el GDD como en la tienda están especificados como 2500 de precio. Anteriormente solo requerían 1500, pero ya se ha ajustado a su precio real (2500).