### PR TITLE
Arreglo de la superposición de elementos en la compra de personajes

### DIFF
--- a/Assets/Scripts/Store/StoreManager.cs
+++ b/Assets/Scripts/Store/StoreManager.cs
@@ -120,30 +120,36 @@ public class StoreManager : MonoBehaviour
             case Rareza.COMUN:
                 if(GameManager.instance.getDineroJugador() >= 150)
                 {
+                    textoNoDinero.text = "";
                     generateRandomCharacter();
                 }
                 else
                 {
+                    stats.SetActive(false);
                     textoNoDinero.text = "No tienes suficiente dinero";
                 }
                 break;
             case Rareza.RARO:
                 if (GameManager.instance.getDineroJugador() >= 500)
                 {
+                    textoNoDinero.text = "";
                     generateRandomCharacter();
                 }
                 else
                 {
+                    stats.SetActive(false);
                     textoNoDinero.text = "No tienes suficiente dinero";
                 }
                 break;
             case Rareza.SUPER_RARO:
                 if (GameManager.instance.getDineroJugador() >= 1500)
                 {
+                    textoNoDinero.text = "";
                     generateRandomCharacter();
                 }
                 else
                 {
+                    stats.SetActive(false);
                     textoNoDinero.text = "No tienes suficiente dinero";
                 }
                 break;


### PR DESCRIPTION
Se quieren añadir los arreglos hechos en la tienda a la rama de desarrollo. Se ha arreglado la superposición del texto de dinero insuficiente a las estadísticas del último personaje comprado. Esto sucedía en la tienda si se intentaban comprar personajes una vez te habías quedado sin dinero, habiendo comprado al menos uno antes.