### PR TITLE
Añadido del mixer al AudioSource

### DIFF
--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -1388,7 +1388,7 @@ AudioSource:
   m_GameObject: {fileID: 1134235860}
   m_Enabled: 1
   serializedVersion: 4
-  OutputAudioMixerGroup: {fileID: 0}
+  OutputAudioMixerGroup: {fileID: 24300002, guid: 2cdae63a47a93a64a993aac549705f29, type: 2}
   m_audioClip: {fileID: 8300000, guid: 5ff69fcae85cbd949b27ff7021ca4c2b, type: 3}
   m_PlayOnAwake: 1
   m_Volume: 1


### PR DESCRIPTION
Se ha añadido el mixer al AudioSource del GameManager, para que al cambiar de volumen en la pantalla de opciones, este se cambie