### PR TITLE
Arreglo de flujo en la escena introductoria

### DIFF
--- a/Assets/Scripts/UIMangament/SceneLoader.cs
+++ b/Assets/Scripts/UIMangament/SceneLoader.cs
@@ -47,7 +47,6 @@ public class SceneLoader : MonoBehaviour
     {
         if(PlayerPrefs.GetInt("PrimeraVez") == 1)
         {
-            PlayerPrefs.SetInt("PrimeraVez", 0);
             SceneManager.LoadScene("Intro Visual Novel");
         } else
         {

--- a/Assets/VNCreator/Behaviors/VNCreator_EndScreen.cs
+++ b/Assets/VNCreator/Behaviors/VNCreator_EndScreen.cs
@@ -27,6 +27,7 @@ namespace VNCreator
 
         void MainMenu()
         {
+            PlayerPrefs.SetInt("PrimeraVez", 0);
             SceneManager.LoadScene(mainMenu, LoadSceneMode.Single);
         }
     }


### PR DESCRIPTION
Se quieren añadir los cambios realizados en la escena introductoria a la rama de desarrollo. Se ha arreglado el flujo respecto a la escena introductoria. Antes, al volver al menú principal desde la escena introductoria, no se podía volver a visualizar, a pesar de no haber terminado necesariamente la escena. Ahora, solo se elimina esta escena del flujo una vez se ha terminado y se ha llegado al menú de selección de niveles, si se vuelve al menú principal se podrá volver a ver.