### PR TITLE
Arreglo problemas audio

### DIFF
--- a/Assets/RecompensaHandler.cs
+++ b/Assets/RecompensaHandler.cs
@@ -11,13 +11,12 @@ public class RecompensaHandler : MonoBehaviour
 
     [SerializeField] private AudioClip clip;
 
-    private void Awake()
-    {
-        GameManager.instance.playSound(clip);
-    }
+    
     // Start is called before the first frame update
     void Start()
     {
+
+        StartCoroutine(GameManager.instance.playSound(clip));
         var nivelData = FindObjectOfType<NivelDataHandler>();
         GameManager.instance.sumarDinero(nivelData.GetMonedas());
 

--- a/Assets/Scenes/Batalla.unity
+++ b/Assets/Scenes/Batalla.unity
@@ -13460,10 +13460,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 1596197862}
   m_HandleRect: {fileID: 675924838}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scenes/Ejercito.unity
+++ b/Assets/Scenes/Ejercito.unity
@@ -2936,10 +2936,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 164806360}
   m_HandleRect: {fileID: 939967399}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scenes/Menu.unity
+++ b/Assets/Scenes/Menu.unity
@@ -333,10 +333,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 1422137615}
   m_HandleRect: {fileID: 1857665340}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scenes/Tienda.unity
+++ b/Assets/Scenes/Tienda.unity
@@ -6433,10 +6433,10 @@ MonoBehaviour:
   m_FillRect: {fileID: 263642339}
   m_HandleRect: {fileID: 1073205464}
   m_Direction: 0
-  m_MinValue: -80
-  m_MaxValue: 0
+  m_MinValue: 0
+  m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0
+  m_Value: 1
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls:

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,6 +10,7 @@ public class GameManager : MonoBehaviour
     [SerializeField] private int dineroJugador = 2500;
     private AudioClip clipMenu;
     private int mundoSeleccionado = 1;
+    private AudioSource audioSorce;
     public GameManager Instance
     {
         get
@@ -37,7 +38,10 @@ public class GameManager : MonoBehaviour
         
         DontDestroyOnLoad(gameObject);
 
-        clipMenu = GetComponent<AudioSource>().clip;
+        
+        audioSorce = GetComponent<AudioSource>();
+        audioSorce.volume = 1;
+        clipMenu = audioSorce.clip;
     }
 
     private void Start()
@@ -71,20 +75,27 @@ public class GameManager : MonoBehaviour
 
     public int GetMundoSeleccionado() { return mundoSeleccionado; }
 
+    public AudioSource GetAudioSource() { return audioSorce; }
+
     public void setClip(AudioClip clip) {
-        if (clip.name != GetComponent<AudioSource>().clip.name)
+        if (clip.name != audioSorce.clip.name)
         {
-            GetComponent<AudioSource>().clip = clip;
-            GetComponent<AudioSource>().Play();
+            audioSorce.clip = clip;
+            audioSorce.Play();
         }
     }
 
-    public void playSound(AudioClip clip)
+    public IEnumerator playSound(AudioClip clip)
     {
-        var audio = GetComponent<AudioSource>().clip;
-        GetComponent<AudioSource>().Stop() ;
-        GetComponent<AudioSource>().PlayOneShot(clip);
-        GetComponent<AudioSource>().clip = clipMenu;
-        GetComponent<AudioSource>().Play();
+        var volumenGeneral = audioSorce.volume;
+        audioSorce.Stop();
+        audioSorce.PlayOneShot(clip);
+        audioSorce.volume = 1;
+        yield return new WaitForSeconds(5f);
+        audioSorce.Stop();
+        audioSorce.volume = volumenGeneral;
+        audioSorce.clip = clipMenu;
+        audioSorce.Play();
     }
+    
 }

--- a/Assets/Scripts/UIMangament/OptionsManager.cs
+++ b/Assets/Scripts/UIMangament/OptionsManager.cs
@@ -17,10 +17,7 @@ public class OptionsManager : MonoBehaviour
     {
         var slider = opciones.GetComponentInChildren<Slider>() as Slider;
 
-        float aux;
-        mainMixer.GetFloat("VolumenGeneral", out aux);
-
-        slider.value = aux;
+        slider.value = GameManager.instance.GetAudioSource().volume;
 
 
         var toggle = opciones.GetComponentInChildren<Toggle>() as Toggle;

--- a/Assets/Scripts/settings/Sound/VolumeManager.cs
+++ b/Assets/Scripts/settings/Sound/VolumeManager.cs
@@ -2,13 +2,13 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Audio;
+using UnityEngine.UI;
 
 public class VolumeManager : MonoBehaviour
 {
     public AudioMixer mixer;
-
     public void ajustarVolumen(float volumen)
     {
-        mixer.SetFloat("VolumenGeneral", volumen);
+        GameManager.instance.GetAudioSource().volume = volumen;
     }
 }

--- a/Assets/SoundGameOver.cs
+++ b/Assets/SoundGameOver.cs
@@ -7,8 +7,9 @@ public class SoundGameOver : MonoBehaviour
 
     [SerializeField] private AudioClip clip;
 
-    private void Awake()
+    private void Start()
     {
-        GameManager.instance.playSound(clip);
+        StartCoroutine(GameManager.instance.playSound(clip));
+       
     }
 }


### PR DESCRIPTION
Se ha arreglado un error en los clips de ganar y perder, que se sobreponían al main theme. Además, se ha ajustado la función del menú de opciones para que cambie apropiadamente el volumen