### PR TITLE
Arreglado errores en colores batalla

### DIFF
--- a/Assets/Scenes/Win.unity
+++ b/Assets/Scenes/Win.unity
@@ -738,7 +738,7 @@ RectTransform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 963615698}
   m_LocalRotation: {x: 0.008718251, y: -0.0003806472, z: 0.043617744, w: 0.9990102}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 0.1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -747,8 +747,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 1, y: 0, z: -5}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 113.64, y: 90}
-  m_SizeDelta: {x: 267.29, y: 33.81}
+  m_AnchoredPosition: {x: 121.8, y: 109.3}
+  m_SizeDelta: {x: 259.79, y: 28.6}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &963615700
 MonoBehaviour:

--- a/Assets/Scripts/Batalla/BattleController.cs
+++ b/Assets/Scripts/Batalla/BattleController.cs
@@ -215,17 +215,53 @@ public class BattleController : MonoBehaviour
         {
             personaje.canSelectable();
             var indiceColores = 0;
-            var lista = colores[indice];
-            foreach(var sprite in personaje.GetComponentsInChildren<SpriteRenderer>())
+            if(colores.Count > 0)
             {
-                sprite.color = lista[indiceColores];
-                indiceColores++;
+
+                if (colores.ContainsKey(indice))
+                {
+                    var lista = colores[indice];
+                    foreach (var sprite in personaje.GetComponentsInChildren<SpriteRenderer>())
+                    {
+                        sprite.color = lista[indiceColores];
+                        indiceColores++;
+                    }
+                }
+                
+                indice++;
             }
-            indice++;
+            
         }
         keyDic = 0;
         colores.Clear();
         seleccionables.Clear();
+    }
+
+    public void resetColores(SeleccionableManager muerto)
+    {
+        Dictionary<int, List<Color>> copia = new Dictionary<int, List<Color>>();
+
+        var indice = 0;
+        var key = 0;
+
+        foreach (var personaje in seleccionables)
+        {
+            if (personaje.Equals(muerto))
+            {
+                
+            }
+            else
+            {
+                copia.Add(key, colores[indice]);
+                key++;
+            }
+            indice++;
+
+        }
+        Debug.Log(copia.Keys);
+        colores.Clear();
+        colores = copia;
+        Debug.Log(colores.Keys);
     }
 
     private void resaltarSingle(CeldaManager celda) 

--- a/Assets/Scripts/IA/LevelFlow.cs
+++ b/Assets/Scripts/IA/LevelFlow.cs
@@ -171,6 +171,7 @@ public class LevelFlow : MonoBehaviour
 
         foreach(var eliminados in persEliminar)
         {
+            GetComponent<BattleController>().resetColores(eliminados.GetComponent<SeleccionableManager>());
             comprobar.Remove(eliminados);
             GetComponent<BattleController>().eliminarMuerto(eliminados.GetComponent<SeleccionableManager>());
             Destroy(eliminados.gameObject);


### PR DESCRIPTION
Se ha arreglado un error que hacía que al morir uno de los personajes, sus colores se imprimiesen en otro personaje.